### PR TITLE
Load kheaders module

### DIFF
--- a/rt-trace-bpf-start
+++ b/rt-trace-bpf-start
@@ -45,6 +45,13 @@ if ! grep -q debugfs /proc/mounts; then
     mount -v -t debugfs none /sys/kernel/debug
 fi
 
+modprobe kheaders
+if [ $? -ne 0 ]; then
+    printf -- "\tUnable to load kheaders module.\n\n"
+    exit 1
+fi
+modinfo kheaders >> rt-trace-bpf-kheaders.txt
+
 cmd="/root/rt-trace-bpf/rt-trace-bcc.py --cpu-list ${cpu_list} --summary --backtrace"
 echo "About to run: ${cmd}"
 ${cmd} > rt-trace-bpf-stderrout.txt


### PR DESCRIPTION
kheaders module contains necessary kernel headers for compiling
ebpf module.