### PR TITLE
Fix kmod and background process

### DIFF
--- a/rt-trace-bpf-start
+++ b/rt-trace-bpf-start
@@ -54,7 +54,7 @@ modinfo kheaders >> rt-trace-bpf-kheaders.txt
 
 cmd="/root/rt-trace-bpf/rt-trace-bcc.py --cpu-list ${cpu_list} --summary --backtrace"
 echo "About to run: ${cmd}"
-${cmd} > rt-trace-bpf-stderrout.txt
+${cmd} > rt-trace-bpf-stderrout.txt &
 rt_trace_bpf_pid=$!
 echo "${rt_trace_bpf_pid}" >> rt-trace-bpf-pids.txt
 echo "rt-trace-bpf pid is ${rt_trace_bpf_pid}"

--- a/workshop.json
+++ b/workshop.json
@@ -26,7 +26,8 @@
 		    "llvm",
 		    "llvm-devel",
 		    "llvm-static",
-		    "ncurses-devel"
+		    "ncurses-devel",
+            "kmod"
 		]
 	    }
 	},


### PR DESCRIPTION
Missing kmod dependency for loading kheaders module

Missing & to run tool in bg, then send signal to kill it