### PR TITLE
Include python3-setuptools dependency

### DIFF
--- a/workshop.json
+++ b/workshop.json
@@ -27,7 +27,8 @@
 		    "llvm-devel",
 		    "llvm-static",
 		    "ncurses-devel",
-            "kmod"
+                    "kmod",
+		    "python3-setuptools"
 		]
 	    }
 	},


### PR DESCRIPTION
setuptools is required for building bcc